### PR TITLE
oauth2_patch.pl doesn't work when installed by npm 3

### DIFF
--- a/oauth2_patch.pl
+++ b/oauth2_patch.pl
@@ -30,4 +30,15 @@ EOS
 my ($fh, $patchfile) = tempfile();
 print $fh $patch;
 close($fh);
-`patch -f node_modules/passport-oauth/node_modules/oauth/lib/oauth2.js < $patchfile`;
+
+my $result = `node -e "require('passport-oauth'); console.log(module.children[0].paths.join(','));"`;
+chomp $result;
+my @paths = split(/,/, $result);
+
+foreach my $path(@paths) {
+    my $target = $path . '/oauth/lib/oauth2.js';
+    if ( -f $target ) {
+        `patch -f $target < $patchfile`;
+        last;
+    }
+}


### PR DESCRIPTION
`oauth2.js` may not exists in `node_modules/passport-oauth/node_modules/oauth/lib/` because npm 3 installs dependencies maximally flat.