### PR TITLE
modify postinstall for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     },
     "scripts" : {
         "test" : "NODE_PATH=lib node_modules/.bin/vows test/*-test.js",
-        "postinstall" : "./oauth2_patch.pl"
+        "postinstall" : "perl ./oauth2_patch.pl"
     },
     "engines" : {
         "node" : ">= 0.4.0"


### PR DESCRIPTION
Because it did not execute in the Windows environment, we responded.